### PR TITLE
Dat257-31 Mapper null reference exception fix

### DIFF
--- a/API/Model/CountryRepository.cs
+++ b/API/Model/CountryRepository.cs
@@ -34,7 +34,10 @@ namespace API.Model
         public Country? GetCountryOfTheDay()
         {
             // TODO: Implement logic to get country of the day
-            return _dbContext.Countries.FirstOrDefault();
+            return _dbContext.Countries
+                .Include (c => c.Data)
+                .ThenInclude(d => d.Points)
+                .FirstOrDefault();
         }
 
         public void AddCountry(Country country)

--- a/API/Utils/Mapper.cs
+++ b/API/Utils/Mapper.cs
@@ -22,7 +22,12 @@ namespace API.Utils
         {
             var countryContracts = new Collection<CountryContract>();
 
-            foreach (Country c in countries)
+            if (countries is null)
+            {
+                return countryContracts;
+            }
+
+            foreach (var c in countries)
             {
                 countryContracts.Add(MapCountry(c));
             }
@@ -34,7 +39,12 @@ namespace API.Utils
         {
             var countryContracts = new Collection<CountryContract>();
 
-            foreach (Country c in countries)
+            if (countries is null)
+            {
+                return countryContracts;
+            }
+
+            foreach (var c in countries)
             {
                 countryContracts.Add(MapCountry(c));
             }
@@ -46,7 +56,12 @@ namespace API.Utils
         {
             var countryContracts = new List<CountryContract>();
 
-            foreach (Country c in countries)
+            if (countries is null)
+            {
+                return countryContracts;
+            }
+
+            foreach (var c in countries)
             {
                 countryContracts.Add(MapCountry(c));
             }
@@ -58,7 +73,12 @@ namespace API.Utils
         {
             var dataContracts = new Collection<DataContract>();
 
-            foreach (Data d in data)
+            if (data is null)
+            {
+                return dataContracts;
+            }
+
+            foreach (var d in data)
             {
                 dataContracts.Add(MapData(d));
             }
@@ -70,7 +90,12 @@ namespace API.Utils
         {
             var dataContracts = new Collection<DataContract>();
 
-            foreach (Data d in data)
+            if (data is null)
+            {
+                return dataContracts;
+            }
+
+            foreach (var d in data)
             {
                 dataContracts.Add(MapData(d));
             }
@@ -82,7 +107,12 @@ namespace API.Utils
         {
             var dataContracts = new List<DataContract>();
 
-            foreach (Data d in data)
+            if (data is null)
+            {
+                return dataContracts;
+            }
+
+            foreach (var d in data)
             {
                 dataContracts.Add(MapData(d));
             }
@@ -97,7 +127,7 @@ namespace API.Utils
                 Name = data.Name,
                 Description = data.Description,
                 Unit = data.Unit,
-                Points = MapDataPointCollection(data.Points)
+                Points = data.Points != null ? MapDataPointCollection(data.Points) : new Collection<DataPointContract>()
             };
         }
 
@@ -105,7 +135,12 @@ namespace API.Utils
         {
             var dataPointContracts = new Collection<DataPointContract>();
 
-            foreach (DataPoint dp in dataPoints)
+            if (dataPoints is null)
+            {
+                return dataPointContracts;
+            }
+
+            foreach (var dp in dataPoints)
             {
                 dataPointContracts.Add(MapDataPoint(dp));
             }
@@ -117,7 +152,7 @@ namespace API.Utils
         {
             var dataPointContracts = new Collection<DataPointContract>();
 
-            foreach (DataPoint dp in dataPoints)
+            foreach (var dp in dataPoints)
             {
                 dataPointContracts.Add(MapDataPoint(dp));
             }

--- a/TestApi/Utils/MapperTest.cs
+++ b/TestApi/Utils/MapperTest.cs
@@ -2,6 +2,7 @@
 using API.Utils;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -121,6 +122,16 @@ namespace TestApi.Utils
         }
 
         [Fact]
+        public static void MapCountryCollection_Null_ReturnsEmptyCollection()
+        {
+            Collection<Country> countries = null;
+
+            var actual = Mapper.MapCountryCollection(countries);
+
+            Assert.Empty(actual);
+        }
+
+        [Fact]
         public static void MapCountryList()
         {
             var countries = new List<Country>
@@ -188,7 +199,17 @@ namespace TestApi.Utils
                 Assert.Equal(countries[i].Data.First().Points.First().Date, countryContracts[i].Data.First().Points.First().Date);
                 Assert.Equal(countries[i].Data.First().Points.First().Value, countryContracts[i].Data.First().Points.First().Value);
             }
-        }   
+        }
+
+        [Fact]
+        public static void MapCountryList_Null_ReturnsEmptyList()
+        {
+            List<Country> list = null;
+
+            var actual = Mapper.MapCountryList(list);
+
+            Assert.Empty(actual);
+        }
 
         [Fact]
         public static void MapDataCollection()
@@ -237,6 +258,16 @@ namespace TestApi.Utils
         }
 
         [Fact]
+        public static void MapDataCollection_Null_ReturnsEmtyCollection()
+        {
+            Collection<Data> data = null;
+
+            var actual = Mapper.MapDataCollection(data);
+
+            Assert.Empty(actual);
+        }
+
+        [Fact]
         public void MapDataList()
         {
             var data = new List<Data>
@@ -280,6 +311,16 @@ namespace TestApi.Utils
                 Assert.Equal(data[i].Points.First().Date, dataContracts[i].Points.First().Date);
                 Assert.Equal(data[i].Points.First().Value, dataContracts[i].Points.First().Value);
             }
+        }
+
+        [Fact]
+        public static void MapDataList_Null_ReturnsEmptyList()
+        {
+            List<Data> data = null;
+
+            var actual = Mapper.MapDataList(data);
+
+            Assert.Empty(actual);
         }
 
         [Fact]
@@ -333,6 +374,16 @@ namespace TestApi.Utils
                 Assert.Equal(dataPoints[i].Date, dataPointContracts[i].Date);
                 Assert.Equal(dataPoints[i].Value, dataPointContracts[i].Value);
             }
+        }
+
+        [Fact]
+        public static void MapDataPointCollection_Null_ReturnsEmptyCollection()
+        {
+            Collection<DataPoint> dataPoints = null;
+
+            var actual = Mapper.MapDataPointCollection(dataPoints);
+
+            Assert.Empty(actual);
         }
 
         [Fact]


### PR DESCRIPTION
Include data and datapoints when getting country of the day and handling null values in Mapper. Update tests to reflect changes in Mapper.