### PR TITLE
Dat257-65 dashboard

### DIFF
--- a/Client/API/ApiRequestHandler.cs
+++ b/Client/API/ApiRequestHandler.cs
@@ -9,7 +9,7 @@ namespace Client.API
 {
     public class ApiRequestHandler : IApiHandler
     {
-        private string apiUrl = "https://localhost:7262";
+        private string apiUrl = "http://localhost:5016";
 
         public async Task<Country> FetchCountryOfTheDay(HttpClient httpClient)
         {
@@ -52,11 +52,11 @@ namespace Client.API
             }
         }
 
-        public async Task<Country> FetchCountryByYear(HttpClient httpClient, string code, DateOnly year)
+        public async Task<Country> FetchCountryByYear(HttpClient httpClient, string code, DateOnly date)
         {
             try
             {
-                return await httpClient.GetFromJsonAsync<Country>($"{apiUrl}/Country/GetCountryDataForYear/{code}/{year}");
+                return await httpClient.GetFromJsonAsync<Country>($"{apiUrl}/Country/GetCountryDataForYear/{code}/{date.Year}-{date.Month}-{date.Day}");
             }
             catch(Exception e)
             {

--- a/Client/Components/DashBoard.razor
+++ b/Client/Components/DashBoard.razor
@@ -9,18 +9,24 @@
     }
     else
     {
-        <div class="data-filter">
-            <DataFilterer Data="@_dataMetrics" OnChange="HandleFilterChange"></DataFilterer>
+        <div class="country-of-the-day">
+            <h2>
+                The country of the day is @_country.Name
+            </h2>
         </div>
-        <nav class="table-of-contents">
-            <h3>Statistics</h3>
-            <ul>
-                @foreach (var metric in _dataMetrics)
-                {
-                    <li><a href="#@FormatLabel(metric)">@metric</a></li>
-                }
-            </ul>
-        </nav>
+        <div class="header"> 
+            <div class="data-filter">
+                <DataFilterer Data="@_dataMetrics" OnChange="HandleFilterChange"></DataFilterer>
+            </div>
+            <nav class="table-of-contents">
+                <ul>
+                    @foreach (var metric in _dataMetrics)
+                    {
+                        <li><a href="#@FormatLabel(metric)">@metric</a></li>
+                    }
+                </ul>
+            </nav>
+        </div>
         <div class="grid-container">
             @foreach (var metric in _dataMetrics)
             {

--- a/Client/Components/DashBoard.razor
+++ b/Client/Components/DashBoard.razor
@@ -14,26 +14,29 @@
                 The country of the day is @_country.Name
             </h2>
         </div>
-        <div class="header"> 
-            <div class="data-filter">
-                <DataFilterer Data="@_dataMetrics" OnChange="HandleFilterChange"></DataFilterer>
-            </div>
-            <nav class="table-of-contents">
-                <ul>
-                    @foreach (var metric in _dataMetrics)
-                    {
-                        <li><a href="#@FormatLabel(metric)">@metric</a></li>
-                    }
-                </ul>
-            </nav>
-        </div>
-        <div class="grid-container">
-            @foreach (var metric in _dataMetrics)
-            {
-                <div id="@FormatLabel(metric)" class="grid-item">
-                    <ComparisonComponent CountryComparison="@_country" CountryOrigin="@_countryToCompareWith" date="@_date" ResourceType="@metric"></ComparisonComponent>
+        <div class="container"> 
+
+            <div class="header"> 
+                <div class="data-filter">
+                    <DataFilterer Data="@_dataMetrics" OnChange="HandleFilterChange"></DataFilterer>
                 </div>
-            }
+                <nav class="table-of-contents">
+                    <ul>
+                        @foreach (var metric in _dataMetrics)
+                        {
+                            <li><a href="#@FormatLabel(metric)">@metric</a></li>
+                        }
+                    </ul>
+                </nav>
+            </div>
+            <div class="grid-container">
+                @foreach (var metric in _dataMetrics)
+                {
+                    <div id="@FormatLabel(metric)" class="grid-item">
+                        <ComparisonComponent CountryComparison="@_country" CountryOrigin="@_countryToCompareWith" date="@_date" ResourceType="@metric"></ComparisonComponent>
+                    </div>
+                }
+            </div>
         </div>
     }
 </div>

--- a/Client/Components/DashBoard.razor.css
+++ b/Client/Components/DashBoard.razor.css
@@ -65,13 +65,25 @@
 
 .grid-item {
     background-color: #f0f0f0;
-    min-height: 50vh;
+    min-height: 25vh;
+    max-height: 60vh;
     text-align: center;
     border-radius: 40px;
     box-shadow: 0 0 15px 1px #808080;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
 }
 
 .header {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    margin-left: 0;
+}
+
+.container {
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: 1fr 6fr;
+    width: 100%;
 }

--- a/Client/Components/DashBoard.razor.css
+++ b/Client/Components/DashBoard.razor.css
@@ -5,6 +5,13 @@
     padding: 25px;
     border-radius: 25px;
     display: flex;
+    flex-direction: column;
+}
+
+.country-of-the-day {
+    width: 100%;
+    text-align: center;
+    padding-bottom: 1rem;
 }
 
 .card-container {
@@ -16,14 +23,40 @@
 }
 
 .table-of-contents {
-    width: 20%;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    color: white;
+}
+
+.table-of-contents ul li  {
+    display: inline-block;
+    background-color: #ffffff;
+    list-style-type: none;
+    margin: 0.5rem 0.5rem 0 0;
+    padding: 10px;
+    border-radius: 0.5rem;
+    border: 1px solid black;
+    transition: all 0.5s;
+}
+
+.table-of-contents ul li :hover {
+    border-bottom: solid 1px black;
+}
+
+.table-of-contents ul li :active {
+    border-bottom: solid 2px black;
+}
+
+.table-of-contents ul li a {
+    text-decoration: none;
+    color: black;
 }
 
 /* Grid settings */
 .grid-container {
     display: grid;
-    grid-template-columns: repeat(3, 1fr); 
+    grid-template-columns: repeat(1, 1fr); 
     grid-gap: 20px;
     margin-top: 20px; 
     padding-left: 20px;
@@ -31,7 +64,14 @@
 }
 
 .grid-item {
-    background-color: #e1417644;
+    background-color: #f0f0f0;
+    min-height: 50vh;
     text-align: center;
     border-radius: 40px;
+    box-shadow: 0 0 15px 1px #808080;
+}
+
+.header {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
 }

--- a/Client/Pages/Home.razor
+++ b/Client/Pages/Home.razor
@@ -5,12 +5,4 @@
 
 <title>Home</title>
 
-<div>
-    <p class="paragraph_country">
-        <img src="sweden-flag.png" alt="Sweden" class="flag" />
-        Sweden</p>
-</div>
-
-<SearchBar/>
-
 <DashBoard></DashBoard>


### PR DESCRIPTION
# Dashboard

## Styling

- Cards take up the entire width of the screen instead of being in a grid.
![image](https://github.com/filipkauffeldt/DAT257-group-8/assets/83284292/051417e5-c1a1-4f17-8163-5e24f7e1af77)
- Cards are 50% of the viewport  height, so it is possible to view two at the same time when you scroll down. Only one visible at the beginning.
![image](https://github.com/filipkauffeldt/DAT257-group-8/assets/83284292/c33efd7b-631f-48ae-bf0b-9fb656eda90e)
- Updated the look of the filtering and quick navigation options.
![image](https://github.com/filipkauffeldt/DAT257-group-8/assets/83284292/e300c86f-b865-44b8-bd61-ca72cd97b5d7)
