### PR TITLE
Dat257 69 change year

### DIFF
--- a/Client/Components/Compare.razor
+++ b/Client/Components/Compare.razor
@@ -26,8 +26,18 @@
                     FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                     FilterOperator="StringFilterOperator.Contains"
                     AllowFiltering=true>
-                </RadzenDropDown>
-                <RadzenLabel Text="with" Component="DropDownBindValue" Style="margin-right: 8px; vertical-align: middle;" Visible=true></RadzenLabel>
+                </RadzenDropDown>                
+                    
+                <div class="data-filter">
+                    <DataFilterer Data="@_nameToCodeMap.Keys"
+                        Text="Choose Countries"
+                        AllowSelectAll=false
+                        DefaultSelectedValues="State.Value.ComparedCountries.Select(c => c.Name)" 
+                        OnChange="HandleCountryChange">
+                    </DataFilterer>
+                </div>
+                <RadzenLabel Text="Select year" Component="DropDownBindValue" Style="margin-right: 8px; vertical-align: middle;" Visible=true></RadzenLabel>
+
                 <RadzenDropDown @bind-Value=@SelectedYear
                                 Data=@ListOfYears
                                 Name="DropDownBindValue"
@@ -40,15 +50,6 @@
                                 FilterOperator="StringFilterOperator.Contains"
                                 AllowFiltering=true>
                 </RadzenDropDown>
-                    
-                <div class="data-filter">
-                    <DataFilterer Data="@_nameToCodeMap.Keys"
-                        Text="Choose Countries"
-                        AllowSelectAll=false
-                        DefaultSelectedValues="State.Value.ComparedCountries.Select(c => c.Name)" 
-                        OnChange="HandleCountryChange">
-                    </DataFilterer>
-                </div>
 
                 <div class="data-filter">
                     <DataFilterer @key=@State.Value.SharedMetrics
@@ -57,7 +58,7 @@
                         DefaultSelectedValues="@State.Value.ShownMetrics" 
                         OnChange="HandleFilterChange">
                     </DataFilterer>
-                
+                </div>
                
                 <nav class="table-of-contents">
                     <ul>

--- a/Client/Components/Compare.razor
+++ b/Client/Components/Compare.razor
@@ -41,8 +41,21 @@
                             FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                             FilterOperator="StringFilterOperator.Contains"
                             AllowFiltering=true>
-                        </RadzenDropDown>  
+                        </RadzenDropDown>
+                   
                 </menu>
+                <RadzenDropDown @bind-Value=@SelectedYear
+                                Data=@ListOfYears
+                                Name="DropDownBindValue"
+                                AllowClear=false
+                                Placeholder=@SelectedYear
+                                Chips=false
+                                MaxSelectedLabels="1"
+                                Change="@((e) => UpdateCountriesBasedOnYear((string)e))"
+                                FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                FilterOperator="StringFilterOperator.Contains"
+                                AllowFiltering=true>
+                </RadzenDropDown>
                     <div class="data-filter">
                     <DataFilterer @key=@State.Value.SharedMetrics Data="@State.Value.SharedMetrics" DefaultSelectedValues="@State.Value.ShownMetrics" OnChange="HandleFilterChange"></DataFilterer>
                 </div>

--- a/Client/Components/Compare.razor.cs
+++ b/Client/Components/Compare.razor.cs
@@ -33,10 +33,11 @@ namespace Client.Components
         private List<string> ListOfYears = new List<string>();
 
         private string SelectedYear;
+
         protected override async Task OnInitializedAsync()
         {
-            _date = State.Value.Year;
-            SelectedYear = _date.Year.ToString();
+            await SetSelectedYear();
+            
             PopulateListOfYears();
             await InitCompareCountryNamesAsync();
             foreach (Country country in State.Value.CountryIdentifiers)
@@ -47,18 +48,35 @@ namespace Client.Components
             await InitComparedCountriesAsync();
             InitSharedMetrics();
             InitShownMetrics();
+            UpdateCountriesBasedOnYear(SelectedYear);
             _initialized = true;
+
             
         }
 
-        private async void PopulateListOfYears()
+        private async Task SetSelectedYear()
+        {
+            _date = State.Value.Year;
+            if (_date.Year < 1950 || _date.Year > DateTime.Today.Year)
+            {
+                // The same value in SelectedYear and _date
+                SelectedYear = "2022";
+                _date = new DateOnly(2022, 1, 1);
+            }
+            else
+            {
+                SelectedYear = _date.Year.ToString();
+            }
+        }
+
+        private void PopulateListOfYears()
         {
             for(int i = DateTime.Today.Year; i >= 1950; i--)
             {
                 ListOfYears.Add(i.ToString());
             }
         }
-        private async void UpdateCountriesBasedOnYear(string year)
+        private void UpdateCountriesBasedOnYear(string year)
         {
             int _year;
             if ( !int.TryParse(year, out _year)) { throw new ParseException("Could not parse string year to int", 1); }

--- a/Client/Components/Compare.razor.cs
+++ b/Client/Components/Compare.razor.cs
@@ -48,7 +48,7 @@ namespace Client.Components
             await InitComparedCountriesAsync();
             InitSharedMetrics();
             InitShownMetrics();
-            UpdateCountriesBasedOnYear(SelectedYear);
+            await UpdateCountriesBasedOnYear(SelectedYear);
             _initialized = true;
 
             
@@ -76,7 +76,7 @@ namespace Client.Components
                 ListOfYears.Add(i.ToString());
             }
         }
-        private void UpdateCountriesBasedOnYear(string year)
+        private async Task UpdateCountriesBasedOnYear(string year)
         {
             int _year;
             if ( !int.TryParse(year, out _year)) { throw new ParseException("Could not parse string year to int", 1); }
@@ -84,7 +84,7 @@ namespace Client.Components
             DateOnly date = new DateOnly(_year,1,1);
             _date = date;
 
-            UpdateOriginCountryAsync(State.Value.OriginCountry.Name);
+            await UpdateOriginCountryAsync(State.Value.OriginCountry.Name);
             RefreshCompCountriesBasedOnYear(State.Value.ComparedCountries);
             Dispatcher.Dispatch(new UpdateYearAction(date));
             StateHasChanged();
@@ -169,7 +169,7 @@ namespace Client.Components
             }
             return sharedMetrics;
         }
-        private async void UpdateOriginCountryAsync(string name)
+        private async Task UpdateOriginCountryAsync(string name)
         {
             var country = await _apiHandler.FetchCountryByYearAsync(_httpClient, _nameToCodeMap[name], _date);
             Dispatcher.Dispatch(new OriginCountryChosenAction(country));

--- a/Client/Components/Compare.razor.cs
+++ b/Client/Components/Compare.razor.cs
@@ -58,9 +58,6 @@ namespace Client.Components
                 ListOfYears.Add(i.ToString());
             }
         }
-
-        // This does not currently work as it should, it never makes a new database request,
-        // which means that it will not get any new data and there for will not be able to show it
         private async void UpdateCountriesBasedOnYear(string year)
         {
             int _year;
@@ -68,14 +65,20 @@ namespace Client.Components
             SelectedYear = year;
             DateOnly date = new DateOnly(_year,1,1);
             _date = date;
-            //Clears list of shown and shared metrics 
-            UpdateShownMetrics(new List<string>());
-            UpdateSharedMetrics(new List<string>());
-            //Gets new list of shown and shared metrics that will be based on the new date
-            InitSharedMetrics();
-            InitShownMetrics();
+
+            UpdateOriginCountryAsync(State.Value.OriginCountry.Name);
+            RefreshCompCountriesBasedOnYear(State.Value.ComparedCountries);
             Dispatcher.Dispatch(new UpdateYearAction(date));
             StateHasChanged();
+        }
+
+        private async void RefreshCompCountriesBasedOnYear(IList<Country> countries)
+        {
+            for (int i = 0; i < countries.Count; i++) 
+            {
+                countries[i] = await _apiHandler.FetchCountryByYearAsync(_httpClient, _nameToCodeMap[countries[i].Name], _date);
+            }
+            UpdateComparedCountries(countries);
         }
 
         private async Task InitCompareCountryNamesAsync() {

--- a/Client/Components/Compare.razor.cs
+++ b/Client/Components/Compare.razor.cs
@@ -64,6 +64,8 @@ namespace Client.Components
             }
         }
 
+        // This does not currently work as it should, it never makes a new database request,
+        // which means that it will not get any new data and there for will not be able to show it
         private async void UpdateCountriesBasedOnYear(string year)
         {
             int _year;
@@ -71,9 +73,10 @@ namespace Client.Components
             SelectedYear = year;
             DateOnly date = new DateOnly(_year,1,1);
             _date = date;
-            //TODO update comparison countries with the new year
+            //Clears list of shown and shared metrics 
             UpdateShownMetrics(new List<string>());
             UpdateSharedMetrics(new List<string>());
+            //Gets new list of shown and shared metrics that will be based on the new date
             InitSharedMetrics();
             InitShownMetrics();
             Dispatcher.Dispatch(new UpdateYearAction(date));

--- a/Client/Components/Compare.razor.css
+++ b/Client/Components/Compare.razor.css
@@ -119,6 +119,7 @@
 
 .grid-container :hover {
     box-shadow: 0 0 15px 1px #057dcd;
+    cursor:pointer;
 }
 
 .header {

--- a/Client/Components/Compare.razor.css
+++ b/Client/Components/Compare.razor.css
@@ -117,6 +117,10 @@
     padding-bottom: 20px;
 }
 
+.grid-container :hover {
+    box-shadow: 0 0 15px 1px #057dcd;
+}
+
 .header {
     display: flex;
     flex-direction: column;

--- a/Client/Components/ComparisonComponent.razor.cs
+++ b/Client/Components/ComparisonComponent.razor.cs
@@ -219,6 +219,10 @@ namespace Client.Components
         public float SetBarWidth()
         {
             float maxValue = ValueMap.Values.Max(valueList => (float)valueList.Max(dataPoint => dataPoint.Value));
+            if(maxValue == 0)
+            {
+                return 1;
+            }
             return maxValue * 1.3f;
         }
     }

--- a/Client/Components/DashBoard.razor.css
+++ b/Client/Components/DashBoard.razor.css
@@ -91,6 +91,7 @@
 
 .grid-container :hover {
     box-shadow: 0 0 15px 1px #057dcd;
+    cursor:pointer;
 }
 
 .header {

--- a/Client/Components/DashBoard.razor.css
+++ b/Client/Components/DashBoard.razor.css
@@ -89,6 +89,10 @@
     padding-bottom: 20px;
 }
 
+.grid-container :hover {
+    box-shadow: 0 0 15px 1px #057dcd;
+}
+
 .header {
     display: flex;
     flex-direction: column;

--- a/Client/Store/Actions/CustomCompareActions.cs
+++ b/Client/Store/Actions/CustomCompareActions.cs
@@ -37,4 +37,14 @@ namespace Client.Store.Actions
         public Country Country { get; }
         public UpdateComparedCountryAction(Country country) => Country = country;
     };
+
+    public class UpdateYearAction
+    {
+        public DateOnly Year { get; }
+
+        public UpdateYearAction(DateOnly year)
+        {
+            this.Year = year;
+        }
+    }
 }

--- a/Client/Store/Reducers/CustomCompareReducers.cs
+++ b/Client/Store/Reducers/CustomCompareReducers.cs
@@ -50,5 +50,13 @@ namespace Client.Store.Reducers
                 CountryIdentifiers = action.CountryIdentifiers
             };
         }
+        [ReducerMethod]
+        public static CustomCompareState CountryIdentifiersDetectedSuccessfullyReducer(CustomCompareState state, UpdateYearAction action)
+        {
+            return state with
+            {
+                Year = action.Year
+            };
+        }
     }
 }

--- a/Client/Store/States/CustomCompareState.cs
+++ b/Client/Store/States/CustomCompareState.cs
@@ -11,5 +11,6 @@ namespace Client.Store.States
         public required IList<string> SharedMetrics { get; init; } = new List<string>();
         public required IList<string> ShownMetrics { get; init; } = new List<string>();
         public required IList<Country> CountryIdentifiers { get; init; }
+        public required DateOnly Year { get; init; }
     }
 }


### PR DESCRIPTION
Added the option to switch to see data from different years. 
There is a bug where all the data is shown as ones when for example the year 2023 or 2024 is chosen. I do not know why but probably because they do not have data for that time. 
It is also quite slow.

Either this goes through or we skip this feature since i do not have time to look at it before the sprints end.